### PR TITLE
Make isolation level configurable

### DIFF
--- a/provider/mysql/isolation.go
+++ b/provider/mysql/isolation.go
@@ -1,0 +1,12 @@
+package mysql
+
+import "database/sql"
+
+// IsolationLevel is a type that represents the isolation level of a transaction.
+type IsolationLevel sql.IsolationLevel
+
+// Allowed isolation levels.
+const (
+	ReadCommittedIsolation = IsolationLevel(sql.LevelReadCommitted)
+	SerializableIsolation  = IsolationLevel(sql.LevelSerializable)
+)

--- a/provider/mysql/options.go
+++ b/provider/mysql/options.go
@@ -1,0 +1,13 @@
+package mysql
+
+import "database/sql"
+
+// Option is a functional option that can be used to configure the store.
+type Option func(*store)
+
+// WithIsolationLevel sets the isolation level for the store.
+func WithIsolationLevel(level IsolationLevel) Option {
+	return func(s *store) {
+		s.isolationLevel = sql.IsolationLevel(level)
+	}
+}


### PR DESCRIPTION
This pull request (PR) aims to make the MySQL store isolation level configurable. By default, it is set to use the serializable isolation level.
